### PR TITLE
Install quickstack modules and staypuft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+modules

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ You must install tools using command (to be found in EPEL)
 
     yum install livecd-tools spin-kickstarts
 
-You need kickstart file from this github repository, currently
+You need kickstart and other scripts file from this github repository, 
+so you should
 
-    git clone https://github.com/radez/foreman-live
+    git clone https://github.com/theforeman/foreman-live
     cd foreman-live
 
 Then you must download discovery images, we currently use those 
@@ -23,6 +24,9 @@ from http://yum.theforeman.org/discovery/nightly/
 
     wget http://yum.theforeman.org/discovery/nightly/discovery-prod-0.3.1-1-initrd.img
     wget http://yum.theforeman.org/discovery/nightly/discovery-prod-0.3.1-1-vmlinuz
+
+You also need to download puppet modules. You can use get_modules.sh 
+script (you must have git installed on your system)
 
 Now you can the create a cd using this following command
 

--- a/foreman-live-centos.ks
+++ b/foreman-live-centos.ks
@@ -759,6 +759,7 @@ cp discovery-prod-0.3.1-1-initrd.img $INSTALL_ROOT/var/lib/tftpboot/boot/discove
 cp setup_provisioning.rb $INSTALL_ROOT/usr/local/src/
 cp foreman.rb $INSTALL_ROOT/usr/local/src/
 cp foreman_setup.sh $INSTALL_ROOT/usr/local/src/
+cp -r modules $INSTALL_ROOT/usr/local/src/modules
 %end
 
 %post
@@ -825,6 +826,7 @@ cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
 foreman
 foreman-installer
 ruby193-rubygem-foreman_discovery
+ruby193-rubygem-staypuft
 
 #foreman dependencies
 bind

--- a/foreman_setup.sh
+++ b/foreman_setup.sh
@@ -39,12 +39,20 @@ sudo foreman-installer \
 # run puppet to seed data into foreman
 sudo puppet agent -t
 
-#adding discovery back in re: http://projects.theforeman.org/issues/4353
-sudo yum localinstall -y http://yum.theforeman.org/releases/latest/el6/x86_64/foreman-release.rpm
-sudo yum install -y ruby193-rubygem-foreman_discovery
-sudo service httpd restart
+
+# upload quickstack modules to /etc/puppet/environments/production/modules
+cp -r /usr/local/src/modules/* /etc/puppet/environments/production/modules
+# import quickstack modules
+foreman-rake puppet:import:puppet_classes[batch]
+# rerun seed because of staypuft
+sudo foreman-rake db:seed
 
 # seed foreman with all necessary provisioning configuration
 cd /home/liveuser
 ./setup_provisioning.rb
 echo "Foreman seeded"
+
+#adding discovery back in re: http://projects.theforeman.org/issues/4353
+sudo yum localinstall -y http://yum.theforeman.org/releases/latest/el6/x86_64/foreman-release.rpm
+sudo yum install -y ruby193-rubygem-foreman_discovery
+sudo service httpd restart

--- a/get_modules.sh
+++ b/get_modules.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+ASTAPOR_VERSION="48781f62d3677f3f2aea996a4861109e7516c0b4"
+OPENSTACK_MODULES_VERSION="d6c6a8c619c0b5fbcf8f9fbb3965f7fdf02947f8"
+
+rm -rf astapor openstack-puppet-modules modules
+mkdir modules
+
+echo "Cloning repositories"
+git clone https://github.com/redhat-openstack/astapor
+git clone --recursive https://github.com/redhat-openstack/openstack-puppet-modules
+
+pushd astapor
+git reset --hard $ASTAPOR_VERSION
+popd
+pushd openstack-puppet-modules
+git reset --hard $OPENSTACK_MODULES_VERSION
+popd
+
+mv astapor/puppet/modules/* modules
+mv openstack-puppet-modules/* modules
+rm -rf astapor openstack-puppet-modules 


### PR DESCRIPTION
Creating a PR without hardcoded modules, they can be downloaded using get_modules.sh script. I put the directory to .gitignore.
